### PR TITLE
ci: use `link-cplusplus`, enable build+test on all branches

### DIFF
--- a/.github/workflows/cargo_build.yml
+++ b/.github/workflows/cargo_build.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "*" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-cplusplus"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +307,7 @@ version = "0.1.0"
 dependencies = [
  "bindgen",
  "cmake",
+ "link-cplusplus",
 ]
 
 [[package]]

--- a/crates/llama_cpp_sys/Cargo.toml
+++ b/crates/llama_cpp_sys/Cargo.toml
@@ -10,6 +10,9 @@ include = ["src/**/*"]
 readme = "../../README.md"
 publish = true
 
+[dependencies]
+link-cplusplus = "1.0.9"
+
 [build-dependencies]
 bindgen = "0.68.1"
 cmake = "0.1.50"

--- a/crates/llama_cpp_sys/build.rs
+++ b/crates/llama_cpp_sys/build.rs
@@ -13,7 +13,7 @@ fn main() {
     }
 
     let dst = cmake::Config::new(SUBMODULE_DIR)
-        .configure_arg("DLLAMA_STATIC=On")
+        .configure_arg("DLLAMA_STATIC=Off")
         .build();
 
     println!("cargo:rustc-link-search=native={}/lib", dst.display());

--- a/crates/llama_cpp_sys/build.rs
+++ b/crates/llama_cpp_sys/build.rs
@@ -13,7 +13,7 @@ fn main() {
     }
 
     let dst = cmake::Config::new(SUBMODULE_DIR)
-        .configure_arg("DLLAMA_STATIC=Off")
+        .configure_arg("DLLAMA_STATIC=On")
         .build();
 
     println!("cargo:rustc-link-search=native={}/lib", dst.display());

--- a/crates/llama_cpp_sys/src/lib.rs
+++ b/crates/llama_cpp_sys/src/lib.rs
@@ -14,4 +14,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+extern crate link_cplusplus;
+
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
Fixes linker errors during the last few invocations of `rustc`; `libcxx` isn't linked by default on Ubuntu.