### PR TITLE
Do not rerun llama_cpp_sys build on changed header files

### DIFF
--- a/crates/llama_cpp_sys/build.rs
+++ b/crates/llama_cpp_sys/build.rs
@@ -61,7 +61,9 @@ fn main() {
     }
 
     if !build_info_path.exists() {
-        fs::write(build_info_path, "\
+        fs::write(
+            build_info_path,
+            "\
             #ifndef BUILD_INFO_H
             #define BUILD_INFO_H
 
@@ -72,7 +74,9 @@ fn main() {
 
             #endif // BUILD_INFO_H
 
-        ").unwrap();
+        ",
+        )
+        .unwrap();
     }
 
     let dst = cmake::Config::new(&build_dir)
@@ -88,7 +92,9 @@ fn main() {
 
     let bindings = bindgen::Builder::default()
         .header(header_path.to_string_lossy())
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .parse_callbacks(Box::new(
+            bindgen::CargoCallbacks::new().rerun_on_header_files(false),
+        ))
         .generate_comments(false)
         .allowlist_function("llama_.*")
         .allowlist_type("llama_.*")


### PR DESCRIPTION
`bindgen` enables this flag by default after its latest update, which isn't what we want because we manually copy the entire CMake directory into `OUT_DIR` at build-time.